### PR TITLE
permit multipleStatements config

### DIFF
--- a/src/MySQL/Connection.purs
+++ b/src/MySQL/Connection.purs
@@ -38,6 +38,7 @@ type ConnectionInfo =
     , dateStrings :: Boolean
     , debug :: Boolean
     , trace :: Boolean
+    , multipleStatements :: Boolean
     }
 
 type QueryOptions =
@@ -62,6 +63,7 @@ defaultConnectionInfo =
   , dateStrings: true
   , debug: false
   , trace: true
+  , multipleStatements : false
   }
 
 


### PR DESCRIPTION
Allow the configuration option to be passed that permits the execution of
multiple statements with a single 'query' or 'execute'.