### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/MySQL/Connection.js
+++ b/src/MySQL/Connection.js
@@ -15,7 +15,7 @@ exports.closeConnection = function(connection) {
   }
 }
 
-exports["_query'"] = function(opts, values, conn) {
+exports._queryImpl = function(opts, values, conn) {
   return function(onError, onSuccess) {
     conn.query(opts, values, function(e, r) {
       if (e) {

--- a/src/MySQL/Connection.purs
+++ b/src/MySQL/Connection.purs
@@ -121,7 +121,7 @@ _query
   -> Array QueryValue
   -> Connection
   -> Aff Foreign
-_query opts values conn = fromEffectFnAff $ runFn3 _query' opts values conn
+_query opts values conn = fromEffectFnAff $ runFn3 _queryImpl opts values conn
 
 foreign import createConnection
   :: ConnectionInfo
@@ -131,7 +131,7 @@ foreign import closeConnection
   :: Connection
   -> Effect Unit
 
-foreign import _query'
+foreign import _queryImpl
   :: Fn3 QueryOptions (Array QueryValue) Connection (EffectFnAff Foreign)
 
 foreign import format


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.